### PR TITLE
Update tolerances on tumbleweed's sysctl.robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,5 +138,15 @@ Based on that you can write checks like:
  `cd ../tests/$SLE_VERSION/`<br>
  `robot sysctl.robot`
 
+ ## Creating a Verification Run
+
+ 1. Have `openqa-clone-job` configured.
+ 2. Fork this repository with your changes in the main branch (there's no support for selecting a custom branch. `%your-repo%` below).
+ 3. Find a previously failing job (`%failing-job%` below. z.B: `https://openqa.opensuse.org/tests/3682089`)
+ 4. Run:
+   ```
+   openqa-clone-job --skip-chained-deps --host openqa.opensuse.org \
+    --from %failing-job% SYS_PARAM_CHECK_TEST=%your-repo% 
+   ```
  ## Contact
  `#team-lsg-qe-core`

--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -100,7 +100,7 @@ Sysctl_fs_inotify_max_user_instances
     Sysctl Check Param Int    fs.inotify.max_user_instances    8192
 Sysctl_fs_inotify_max_user_watches
     [Documentation]    Depends of the RAM resources bsc#1183339#c11
-    Sysctl Check Param Int    fs.inotify.max_user_watches    15070%0.1
+    Sysctl Check Param Int    fs.inotify.max_user_watches    15070%0.5
 Sysctl_fs_lease-break-time
     Sysctl Check Param Int    fs.lease-break-time    45
 Sysctl_fs_leases-enable
@@ -1880,7 +1880,7 @@ Sysctl_user_max_fanotify_groups
     Sysctl Check Param Int    user.max_fanotify_groups    128
 Sysctl_user_max_fanotify_marks
     [Documentation]    Depends of the RAM resources bsc#1183339#c11
-    Sysctl Check Param Int    user.max_fanotify_marks    16024%0.1
+    Sysctl Check Param Int    user.max_fanotify_marks    16024%0.5
 Sysctl_user_max_inotify_instances
     Sysctl Check Param Int    user.max_inotify_instances    8192
 Sysctl_user_max_inotify_watches

--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -1884,7 +1884,8 @@ Sysctl_user_max_fanotify_marks
 Sysctl_user_max_inotify_instances
     Sysctl Check Param Int    user.max_inotify_instances    8192
 Sysctl_user_max_inotify_watches
-    Sysctl Check Param Int    user.max_inotify_watches    15070
+    [Documentation]    Depends of the RAM resources bsc#1183339#c11
+    Sysctl Check Param Int    user.max_inotify_watches    15070%0.5
 Sysctl_vm_admin_reserve_kbytes
     Sysctl Check Param Int    vm.admin_reserve_kbytes    8192
 Sysctl_vm_compact_unevictable_allowed

--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -1918,7 +1918,8 @@ Sysctl_vm_legacy_va_layout
 Sysctl_vm_lowmem_reserve_ratio
     Sysctl Check Param Int    vm.lowmem_reserve_ratio    256 256 32 0 0
 Sysctl_vm_max_map_count
-    Sysctl Check Param Int    vm.max_map_count    65530
+    [Documentation] Increased as per bsc#1214445
+    Sysctl Check Param Int    vm.max_map_count    1048576
 Sysctl_vm_memory_failure_early_kill
     Sysctl Check Param Int    vm.memory_failure_early_kill    0
 Sysctl_vm_memory_failure_recovery

--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -99,7 +99,8 @@ Sysctl_fs_inotify_max_queued_events
 Sysctl_fs_inotify_max_user_instances
     Sysctl Check Param Int    fs.inotify.max_user_instances    8192
 Sysctl_fs_inotify_max_user_watches
-    Sysctl Check Param Int    fs.inotify.max_user_watches    15070
+    [Documentation]    Depends of the RAM resources bsc#1183339#c11
+    Sysctl Check Param Int    fs.inotify.max_user_watches    15070%0.05
 Sysctl_fs_lease-break-time
     Sysctl Check Param Int    fs.lease-break-time    45
 Sysctl_fs_leases-enable
@@ -311,7 +312,8 @@ Sysctl_kernel_sched_child_runs_first
 Sysctl_kernel_sched_energy_aware
     Sysctl Check Param Int    kernel.sched_energy_aware    1
 Sysctl_kernel_sched_rr_timeslice_ms
-    Sysctl Check Param Int    kernel.sched_rr_timeslice_ms   90
+    [Documentation] Brought back from #6
+    Sysctl Check Param Int    kernel.sched_rr_timeslice_ms   90:100
 Sysctl_kernel_sched_rt_period_us
     Sysctl Check Param Int    kernel.sched_rt_period_us    1000000
 Sysctl_kernel_sched_rt_runtime_us
@@ -1877,7 +1879,8 @@ Sysctl_net_unix_max_dgram_qlen
 Sysctl_user_max_fanotify_groups
     Sysctl Check Param Int    user.max_fanotify_groups    128
 Sysctl_user_max_fanotify_marks
-    Sysctl Check Param Int    user.max_fanotify_marks    16024
+    [Documentation]    Depends of the RAM resources bsc#1183339#c11
+    Sysctl Check Param Int    user.max_fanotify_marks    16024%0.05
 Sysctl_user_max_inotify_instances
     Sysctl Check Param Int    user.max_inotify_instances    8192
 Sysctl_user_max_inotify_watches

--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -100,7 +100,7 @@ Sysctl_fs_inotify_max_user_instances
     Sysctl Check Param Int    fs.inotify.max_user_instances    8192
 Sysctl_fs_inotify_max_user_watches
     [Documentation]    Depends of the RAM resources bsc#1183339#c11
-    Sysctl Check Param Int    fs.inotify.max_user_watches    15070%0.05
+    Sysctl Check Param Int    fs.inotify.max_user_watches    15070%0.1
 Sysctl_fs_lease-break-time
     Sysctl Check Param Int    fs.lease-break-time    45
 Sysctl_fs_leases-enable
@@ -1880,7 +1880,7 @@ Sysctl_user_max_fanotify_groups
     Sysctl Check Param Int    user.max_fanotify_groups    128
 Sysctl_user_max_fanotify_marks
     [Documentation]    Depends of the RAM resources bsc#1183339#c11
-    Sysctl Check Param Int    user.max_fanotify_marks    16024%0.05
+    Sysctl Check Param Int    user.max_fanotify_marks    16024%0.1
 Sysctl_user_max_inotify_instances
     Sysctl Check Param Int    user.max_inotify_instances    8192
 Sysctl_user_max_inotify_watches

--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -312,7 +312,7 @@ Sysctl_kernel_sched_child_runs_first
 Sysctl_kernel_sched_energy_aware
     Sysctl Check Param Int    kernel.sched_energy_aware    1
 Sysctl_kernel_sched_rr_timeslice_ms
-    [Documentation] Brought back from #6
+    [Documentation]    Brought back from #6
     Sysctl Check Param Int    kernel.sched_rr_timeslice_ms   90:100
 Sysctl_kernel_sched_rt_period_us
     Sysctl Check Param Int    kernel.sched_rt_period_us    1000000
@@ -1884,7 +1884,7 @@ Sysctl_user_max_fanotify_marks
 Sysctl_user_max_inotify_instances
     Sysctl Check Param Int    user.max_inotify_instances    8192
 Sysctl_user_max_inotify_watches
-    Sysctl Check Param Int    user.max_inotify_watches    15070%0.05
+    Sysctl Check Param Int    user.max_inotify_watches    15070
 Sysctl_vm_admin_reserve_kbytes
     Sysctl Check Param Int    vm.admin_reserve_kbytes    8192
 Sysctl_vm_compact_unevictable_allowed
@@ -1918,7 +1918,7 @@ Sysctl_vm_legacy_va_layout
 Sysctl_vm_lowmem_reserve_ratio
     Sysctl Check Param Int    vm.lowmem_reserve_ratio    256 256 32 0 0
 Sysctl_vm_max_map_count
-    [Documentation] Increased as per bsc#1214445
+    [Documentation]    Increased as per bsc#1214445
     Sysctl Check Param Int    vm.max_map_count    1048576
 Sysctl_vm_memory_failure_early_kill
     Sysctl Check Param Int    vm.memory_failure_early_kill    0

--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -1884,7 +1884,7 @@ Sysctl_user_max_fanotify_marks
 Sysctl_user_max_inotify_instances
     Sysctl Check Param Int    user.max_inotify_instances    8192
 Sysctl_user_max_inotify_watches
-    Sysctl Check Param Int    user.max_inotify_watches    15070
+    Sysctl Check Param Int    user.max_inotify_watches    15070%0.05
 Sysctl_vm_admin_reserve_kbytes
     Sysctl Check Param Int    vm.admin_reserve_kbytes    8192
 Sysctl_vm_compact_unevictable_allowed


### PR DESCRIPTION
Brought back a tolerance from #6 in here.

`Sysctl_fs_inotify_max_user_watches` and `Sysctl_user_max_fanotify_marks` now have a 5% tolerance, due to those values being computed from the resources of the system under test.

Addresses: [poo#135722](https://progress.opensuse.org/issues/135722)


VR: https://openqa.opensuse.org/tests/3762163

