### PR TITLE
Fix some format issues

### DIFF
--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -1880,12 +1880,12 @@ Sysctl_user_max_fanotify_groups
     Sysctl Check Param Int    user.max_fanotify_groups    128
 Sysctl_user_max_fanotify_marks
     [Documentation]    Depends of the RAM resources bsc#1183339#c11 bsc#1219366
-    Sysctl Check Param Int    user.max_fanotify_marks    8192 1048576
+    Sysctl Check Param Int    user.max_fanotify_marks    8192:1048576
 Sysctl_user_max_inotify_instances
     Sysctl Check Param Int    user.max_inotify_instances    8192
 Sysctl_user_max_inotify_watches
     [Documentation]    Depends of the RAM resources bsc#1183339#c11 bsc#1219366
-    Sysctl Check Param Int    user.max_inotify_watches   8192 1048576
+    Sysctl Check Param Int    user.max_inotify_watches   8192:1048576
 Sysctl_vm_admin_reserve_kbytes
     Sysctl Check Param Int    vm.admin_reserve_kbytes    8192
 Sysctl_vm_compact_unevictable_allowed

--- a/tests/sles-15-SP4/sysctl.robot
+++ b/tests/sles-15-SP4/sysctl.robot
@@ -373,10 +373,7 @@ Sysctl_net_core_bpf_jit_kallsyms
     [Documentation]    Set to 1 from 0 for debuging purpose, os not released yet
     Sysctl Check Param Int    net.core.bpf_jit_kallsyms    1
 Sysctl_net_core_bpf_jit_limit
-<<<<<<< HEAD
     [Documentation]    Adjust insufficient default bpf_jit_limit (SLE Micro 5.4/Elemental) bsc#1218234
-=======
->>>>>>> 5094e06 (Adjust insufficient default bpf_jit_limit)
     Sysctl Check Param Int    net.core.bpf_jit_limit    528482304
 Sysctl_net_core_busy_poll
     Sysctl Check Param Int    net.core.busy_poll    0

--- a/tests/sles-15-SP4/sysctl.robot
+++ b/tests/sles-15-SP4/sysctl.robot
@@ -373,7 +373,10 @@ Sysctl_net_core_bpf_jit_kallsyms
     [Documentation]    Set to 1 from 0 for debuging purpose, os not released yet
     Sysctl Check Param Int    net.core.bpf_jit_kallsyms    1
 Sysctl_net_core_bpf_jit_limit
+<<<<<<< HEAD
     [Documentation]    Adjust insufficient default bpf_jit_limit (SLE Micro 5.4/Elemental) bsc#1218234
+=======
+>>>>>>> 5094e06 (Adjust insufficient default bpf_jit_limit)
     Sysctl Check Param Int    net.core.bpf_jit_limit    528482304
 Sysctl_net_core_busy_poll
     Sysctl Check Param Int    net.core.busy_poll    0

--- a/tests/sles-15-SP6/sysctl.robot
+++ b/tests/sles-15-SP6/sysctl.robot
@@ -1911,12 +1911,12 @@ Sysctl_user_max_fanotify_groups
     Sysctl Check Param Int    user.max_fanotify_groups    128
 Sysctl_user_max_fanotify_marks
     [Documentation]    Depends of the RAM resources bsc#1183339#c11 bsc#1219366
-    Sysctl Check Param Int    user.max_fanotify_marks    8192 1048576
+    Sysctl Check Param Int    user.max_fanotify_marks    8192:1048576
 Sysctl_user_max_inotify_instances
     Sysctl Check Param Int    user.max_inotify_instances    128
 Sysctl_user_max_inotify_watches
     [Documentation]    Depends of the RAM resources bsc#1183339#c11 bsc#1219366
-    Sysctl Check Param Int    user.max_inotify_watches   8192 1048576
+    Sysctl Check Param Int    user.max_inotify_watches   8192:1048576
 Sysctl_vm_admin_reserve_kbytes
     Sysctl Check Param Int    vm.admin_reserve_kbytes    8192
 Sysctl_vm_compact_unevictable_allowed


### PR DESCRIPTION
The failed job: https://openqa.suse.de/tests/13539521#step/Sysctl/935
```
# Test messages # Sysctl_user_max_fanotify_marks
# failure: 

invalid number of values: return values 1, expexted 2
```

VR: http://openqa.suse.de/tests/13539531#