### PR TITLE
Change route_max_size from 4096 to 2147483647

### DIFF
--- a/tests/sles-12-SP5/sysctl.robot
+++ b/tests/sles-12-SP5/sysctl.robot
@@ -1516,7 +1516,7 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
-    Sysctl Check Param Int    net.ipv6.route.max_size    4096
+    Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220
 Sysctl_net_ipv6_route_mtu_expires

--- a/tests/sles-12-SP5/sysctl.robot
+++ b/tests/sles-12-SP5/sysctl.robot
@@ -1516,6 +1516,7 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
+    [Documentation]    bsc#1219295 VUL-0: CVE-2023-52340: kernel: ICMPv6 “Packet Too Big”
     Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220

--- a/tests/sles-15-SP5/sysctl.robot
+++ b/tests/sles-15-SP5/sysctl.robot
@@ -1603,6 +1603,7 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
+    [Documentation]    bsc#1219295 VUL-0: CVE-2023-52340: kernel: ICMPv6 “Packet Too Big”
     Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220

--- a/tests/sles-15-SP5/sysctl.robot
+++ b/tests/sles-15-SP5/sysctl.robot
@@ -1603,7 +1603,7 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
-    Sysctl Check Param Int    net.ipv6.route.max_size    4096
+    Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220
 Sysctl_net_ipv6_route_mtu_expires


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1219295
ipv6-remove-max_size-check-inline-with-ipv4.patch
```
...
-        net->ipv6.sysctl.ip6_rt_max_size = 4096;
+        net->ipv6.sysctl.ip6_rt_max_size = INT_MAX;
...
```
12-SP5 https://build.suse.de/request/show/323487
15-SP5 https://build.suse.de/request/show/323489