### PR TITLE
Change route_max_size from 4096 to 2147483647

### DIFF
--- a/tests/sles-15-SP2/sysctl.robot
+++ b/tests/sles-15-SP2/sysctl.robot
@@ -1598,7 +1598,8 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
-    Sysctl Check Param Int    net.ipv6.route.max_size    4096
+    [Documentation]    bsc#1219295 VUL-0: CVE-2023-52340: kernel: ICMPv6 “Packet Too Big”
+    Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220
 Sysctl_net_ipv6_route_mtu_expires

--- a/tests/sles-15-SP3/sysctl.robot
+++ b/tests/sles-15-SP3/sysctl.robot
@@ -1606,7 +1606,8 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
-    Sysctl Check Param Int    net.ipv6.route.max_size    4096
+    [Documentation]    bsc#1219295 VUL-0: CVE-2023-52340: kernel: ICMPv6 “Packet Too Big”
+    Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220
 Sysctl_net_ipv6_route_mtu_expires

--- a/tests/sles-15-SP4/sysctl.robot
+++ b/tests/sles-15-SP4/sysctl.robot
@@ -1603,7 +1603,8 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
-    Sysctl Check Param Int    net.ipv6.route.max_size    4096
+    [Documentation]    bsc#1219295 VUL-0: CVE-2023-52340: kernel: ICMPv6 “Packet Too Big”
+    Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220
 Sysctl_net_ipv6_route_mtu_expires


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1219295
ipv6-remove-max_size-check-inline-with-ipv4.patch
...
-        net->ipv6.sysctl.ip6_rt_max_size = 4096;
+        net->ipv6.sysctl.ip6_rt_max_size = INT_MAX;
...

Add this change also to 15-SP2 15-SP3 15-SP4 to fix:
https://openqa.suse.de/tests/13764739#step/Sysctl/784
https://openqa.suse.de/tests/13764059#step/Sysctl/784
https://openqa.suse.de/tests/13764060#step/Sysctl/782