### PR TITLE
12sp3: Change route_max_size from 4096 to 2147483647

### DIFF
--- a/tests/sles-12-SP3/sysctl.robot
+++ b/tests/sles-12-SP3/sysctl.robot
@@ -1386,7 +1386,8 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
-    Sysctl Check Param Int    net.ipv6.route.max_size    4096
+    [Documentation]    bsc#1219295 VUL-0: CVE-2023-52340: kernel: ICMPv6 “Packet Too Big”
+    Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220
 Sysctl_net_ipv6_route_mtu_expires


### PR DESCRIPTION
Same as for updates on other versions
c5bf19342dcda5cc4d3c38849cf984989d8854f6
1c4bea615bd90e675a8c5d8a2f40bea2a4a5396e