### PR TITLE
Fix Sysctl_kernel_sched_energy_aware value on Tumbleweed

### DIFF
--- a/tests/Tumbleweed/sysctl.robot
+++ b/tests/Tumbleweed/sysctl.robot
@@ -310,7 +310,8 @@ Sysctl_kernel_sched_cfs_bandwidth_slice_us
 Sysctl_kernel_sched_child_runs_first
     Sysctl Check Param Int    kernel.sched_child_runs_first    0
 Sysctl_kernel_sched_energy_aware
-    Sysctl Check Param Int    kernel.sched_energy_aware    1
+    [Documentation]    Return an empty string in case EAS is not supported bsc#1219132
+    Sysctl Check Param Empty    kernel.sched_energy_aware
 Sysctl_kernel_sched_rr_timeslice_ms
     [Documentation]    Brought back from #6
     Sysctl Check Param Int    kernel.sched_rr_timeslice_ms   90:100


### PR DESCRIPTION
https://progress.opensuse.org/issues/160880
https://bugzilla.opensuse.org/show_bug.cgi?id=1219132

VR:https://openqa.opensuse.org/tests/4246131#step/Sysctl/136

![Screenshot from 2024-06-04 16-11-24](https://github.com/openSUSE/sys-param-check/assets/59351158/f4739bfe-e032-4120-af76-611912fb75fc)

**Please ignore other failed scenarios, they are known issues**