### PR TITLE
Old value for net.ipv6.route.max_size on 12-SP3 TD

### DIFF
--- a/tests/sles-12-SP3/sysctl.robot
+++ b/tests/sles-12-SP3/sysctl.robot
@@ -1386,8 +1386,7 @@ Sysctl_net_ipv6_route_gc_thresh
 Sysctl_net_ipv6_route_gc_timeout
     Sysctl Check Param Int    net.ipv6.route.gc_timeout    60
 Sysctl_net_ipv6_route_max_size
-    [Documentation]    bsc#1219295 VUL-0: CVE-2023-52340: kernel: ICMPv6 “Packet Too Big”
-    Sysctl Check Param Int    net.ipv6.route.max_size    2147483647
+    Sysctl Check Param Int    net.ipv6.route.max_size    4096
 Sysctl_net_ipv6_route_min_adv_mss
     Sysctl Check Param Int    net.ipv6.route.min_adv_mss    1220
 Sysctl_net_ipv6_route_mtu_expires


### PR DESCRIPTION
https://suse.slack.com/archives/C02CLB8TZP1/p1738051987125859