### PR TITLE
Update instructions for verification runs with custom branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,13 @@ Based on that you can write checks like:
  ## Creating a Verification Run
 
  1. Have `openqa-clone-job` configured.
- 2. Fork this repository with your changes in the main branch (there's no support for selecting a custom branch. `%your-repo%` below).
+ 2. Fork this repository, `%your-repo%` and `%branch%` (i.e `git rev-parse --abbrev-ref HEAD`).
  3. Find a previously failing job (`%failing-job%` below. z.B: `https://openqa.opensuse.org/tests/3682089`)
  4. Run:
    ```
    openqa-clone-job --skip-chained-deps --host openqa.opensuse.org \
-    --from %failing-job% SYS_PARAM_CHECK_TEST=%your-repo% 
+    --from %failing-job% SYS_PARAM_CHECK_REPO=%your-repo% SYS_PARAM_CHECK_BRANCH=%branch%
    ```
+
  ## Contact
  `#team-lsg-qe-core`


### PR DESCRIPTION
Looking at the test code, branch can be passed with `SYS_PARAM_CHECK_BRANCH` which makes it easier to test changes (not that there are many)
