### PR TITLE
coredump: Revert new %d flag on 15-SP7

### DIFF
--- a/tests/sles-15-SP7/sysctl.robot
+++ b/tests/sles-15-SP7/sysctl.robot
@@ -167,7 +167,7 @@ Sysctl_kernel_cad_pid
 Sysctl_kernel_cap_last_cap
     Sysctl Check Param Int    kernel.cap_last_cap    40
 Sysctl_kernel_core_pattern
-    Sysctl Check Param Str    kernel.core_pattern    |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h %d
+    Sysctl Check Param Str    kernel.core_pattern    |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h
 Sysctl_kernel_core_pipe_limit
     Sysctl Check Param Int    kernel.core_pipe_limit    16
 Sysctl_kernel_core_uses_pid


### PR DESCRIPTION
not changed right now

6c6e1eed63d7f49d51c4a0a7a298d8bd1c87afff
https://bugzilla.suse.com/show_bug.cgi?id=1243935