### PR TITLE
Adjust systemd-coredump parameter for sle16

### DIFF
--- a/tests/sles-16.0/sysctl.robot
+++ b/tests/sles-16.0/sysctl.robot
@@ -168,7 +168,7 @@ Sysctl_kernel_cad_pid
 Sysctl_kernel_cap_last_cap
     Sysctl Check Param Int    kernel.cap_last_cap    40
 Sysctl_kernel_core_pattern
-    Sysctl Check Param Str    kernel.core_pattern    |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h
+    Sysctl Check Param Str    kernel.core_pattern    |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h %d %F
 Sysctl_kernel_core_pipe_limit
     Sysctl Check Param Int    kernel.core_pipe_limit    16
 Sysctl_kernel_core_uses_pid


### PR DESCRIPTION
https://progress.opensuse.org/issues/184927

VR: http://openqa.suse.de/tests/18262969/file/sys_param_check-sysctl.robot.html#s1-t65